### PR TITLE
Extend load store

### DIFF
--- a/docs/asm_instructions.md
+++ b/docs/asm_instructions.md
@@ -52,7 +52,7 @@ Abbreviations :
 |      r       | register                               |
 |     *n       | in-place numerical value               |
 |     sp       | stack pointer   (ls, gs)               |
-|     *sp      | stack pointer offset  ($N(ls), $N(gs)) |
+|     *sp      | stack pointer offset  ($N(ls), $N(gs)) or rN(ls), rN(gs) for register-based offset |
 
 ## Misc Instructions
 | Instruction     | Arg1      | Arg2          | Arg3         | Description                                  |
@@ -258,13 +258,27 @@ Indication Bits:
 
 **stb** - Store bytes
 
+Indication Bits:
+00 - Stack with numerical offset, Source Register
+01 - Stack with register-base offset, Source Register
+
     INS    ID    STACK       [ ---------------   ADDRESS  ---------------]   REGISTER    UNUSED
     111111 00 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111
 
+    INS    ID    STACK      REGISTER     REGISTER   [ ------------------ UNUSED ----------------]
+    111111 01 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111
+
 **ldb** - Load bytes
+
+Indication Bits:
+00 - Destination Register, Stack with numerical offset
+01 - Destination Register, Stack with register-base offset
 
     INS    ID   REGISTER      STACK     [ ---------------   ADDRESS  ---------------]    UNUSED
     111111 00 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111
+
+    INS    ID    REGISTER      STACK     REGISTER   [ ------------------ UNUSED ----------------]
+    111111 01 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111
 
 **push** - Push
 

--- a/docs/asm_instructions.md
+++ b/docs/asm_instructions.md
@@ -58,7 +58,7 @@ Abbreviations :
 | Instruction     | Arg1      | Arg2          | Arg3         | Description                                  |
 |---              |---        |---            |---           |---                                           |
 |     nop         |    NA     |    NA         |   NA         |  No Operation                                |
-
+|     size        |    sp     |    NA         |   NA         |  Get size (number of elements) in stack      |
 
 ## Artihmatic Instructions
 | Instruction     | Arg1      | Arg2          | Arg3         | Description                                  |
@@ -349,6 +349,19 @@ The current maximum is 255 bytes for a string
 id bits ignored, size is 9 bytes fixed
 
     INS    ID   [ -------------------------------------- DOUBLE DATA -------------------------------------- ]
+    111111 00 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111
+
+
+## Misc Instructions
+
+Nop
+
+    INS    ID   [ --------------------------------------   UNUSED  ---------------------------------------- ]
+    111111 00 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111
+
+Size
+
+    INS    ID   REGISTER    STACK      [ ---------------------------- UNUSED -------------------------------]
     111111 00 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111 | 1111 1111
 
 

--- a/docs/vm-about.md
+++ b/docs/vm-about.md
@@ -39,8 +39,6 @@ Binary encoding (from file) will treat numerical values the same as strings. Tha
     Possible Instructions   ( lowest 2 bits must be 0 )
 
 
-    0	| 00000000
-    4	| 00000100
     8	| 00001000
     c	| 00001100
     10	| 00010000
@@ -64,6 +62,7 @@ Binary encoding (from file) will treat numerical values the same as strings. Tha
     
 
     [ BELOW ARE CURRENT INSTRUCTIONS ]
+    4	| 00000100
     0	| 00000000
     44	| 01000100
     48	| 01001000

--- a/src/apps/nabla/tests/baseInstructionTests.cpp
+++ b/src/apps/nabla/tests/baseInstructionTests.cpp
@@ -800,6 +800,7 @@ TEST(NablaInstructionTests, pushPopIns)
         vm_delete(vm);
     }
 }
+
 // ---------------------------------------------------------------
 // 
 // ---------------------------------------------------------------
@@ -1321,5 +1322,82 @@ TEST(NablaInstructionTests, bitwiseIns)
 
             vm_delete(vm);
         }
+    }
+}
+
+// ---------------------------------------------------------------
+// 
+// ---------------------------------------------------------------
+
+TEST(NablaInstructionTests, sizeInstruction)
+{
+    for(int i = 0; i < 100; i++)
+    {
+        NABLA::Bytegen bytegen;
+        NablaVirtualMachine vm = vm_new();
+
+        NABLA::Bytegen::Stacks stackLoc = static_cast<NABLA::Bytegen::Stacks>(getRandom16(0,1));
+
+        // A register to get data from for push instructions used to grow the stack for testing
+        uint16_t pushReg = getRandom16(0, 9);
+
+        // Where the size instruction should be placing size once acquired
+        uint16_t dest_reg = getRandom16(0, 9);
+
+        // Ensure push and pop reg differ
+        while(pushReg == dest_reg)
+        {
+            dest_reg = getRandom16(0, 9);
+        }
+
+        // Put some random value, we really don't care what it is
+        vm->registers[pushReg] = getRandom16(0, 65530);
+
+        // Create a size instruction that should read '0' when called 
+        NABLA::Bytegen::Instruction sizeIns = bytegen.createSizeInstruction(dest_reg, stackLoc);
+
+        std::vector<uint8_t> sizeInsBytes = ins_to_vec(sizeIns);
+        build_test_vm(vm, sizeInsBytes);
+
+        // Grow the stack some number of sizes
+        uint8_t numPushs = getRandom16(0, 55);
+
+        for(int sp = 0; sp < numPushs; sp++)
+        {
+            NABLA::Bytegen::Instruction pushIns = bytegen.createPushInstruction(
+                stackLoc, pushReg
+            );
+
+            std::vector<uint8_t> pushBytes = ins_to_vec(pushIns);
+            build_test_vm(vm, pushBytes);
+        }
+
+        // Create a stack instruction that should read back numPushs
+        sizeInsBytes.clear();
+        sizeInsBytes = ins_to_vec(bytegen.createSizeInstruction(dest_reg, stackLoc));
+        build_test_vm(vm, sizeInsBytes);
+
+        // Init
+        vm_init(vm);
+
+        // Step 1 instruction (should be push)
+        vm_step(vm, 1);
+
+        // Size should have read 0
+        CHECK_EQUAL(0, vm->registers[dest_reg]);
+
+        // Step all of the push instructions
+        vm_step(vm, numPushs);
+     
+        // Sanity check
+        CHECK_EQUAL(0, vm->registers[dest_reg]);
+        
+        // Execute the 2nd size instruction
+        vm_step(vm, 1);
+
+        // Make sure its reading a size of 'numPushs'
+        CHECK_EQUAL(numPushs, vm->registers[dest_reg]);
+
+        vm_delete(vm);
     }
 }

--- a/src/apps/solace/solace_code/bitwise.asm
+++ b/src/apps/solace/solace_code/bitwise.asm
@@ -1,0 +1,42 @@
+.file "newasm"
+.init main
+
+<main:
+
+    mov r9  $8
+    mov r10 $4
+    mov r11 $1
+
+    lsh r0 r9 $4    ; 128
+    lsh r0 r9 r10   ; 128
+    lsh r0 $4 r9    ; 1024
+    lsh r0 $4 $8    ; 1024
+
+    rsh r0 r9 $4       ; 0
+    rsh r0 r9 r10      ; 0
+    rsh r0 $1024 r9    ; 4 
+    rsh r0 $1024 $8    ; 4 
+
+    and r0 r10 $4    ; 4
+    and r0 r9 r10    ; 0
+    and r0 $4 r9     ; 0
+    and r0 $4 $4     ; 4
+
+    or r0 r9 $4     ; 12
+    or r0 r9 r10    ; 12
+    or r0 $4 r9     ; 12
+    or r0 $4 $8     ; 12
+
+    xor r0 r9 $4    ; 12
+    xor r0 r9 r10   ; 12
+    xor r0 $4 r9    ; 12
+    xor r0 $4 $8    ; 12
+
+    not r0 $1       ; -2
+    not r0 r11      ; -2
+
+    nop
+    nop
+
+    ret
+>

--- a/src/apps/solace/solace_code/new_ins.asm
+++ b/src/apps/solace/solace_code/new_ins.asm
@@ -53,12 +53,14 @@
 
     mov r4 $0
 
-    ;ldb r11 r4(gs) ; Load the 0th item from global stack (should be constant 'test')
+    ldb r11 r4(gs) ; Load the 0th item from global stack (should be constant 'test')
 
     mov r4 $4
     mov r5 $33
 
-    ;stb r4(gs) r5  ; Store 33 into gs at index 4
+    stb r4(gs) r5  ; Store 33 into gs at index 4
+
+    ldb r11 $4(gs)
 >
 
 <testregrefls:
@@ -73,7 +75,7 @@
     mov r0 $2
     mov r7 $45
 
-    ;stb r0(ls) r7  ; Store 45 into index 2 (spot 3) of ls
-    ;ldb r11 r0(ls) ; Load index 2 (spot 3) into rll
+    stb r0(ls) r7  ; Store 45 into index 2 (spot 3) of ls
+    ldb r11 r0(ls) ; Load index 2 (spot 3) into rll
 
 >

--- a/src/apps/solace/solace_code/new_ins.asm
+++ b/src/apps/solace/solace_code/new_ins.asm
@@ -36,8 +36,17 @@
 
 <testsize:
 
-    ;size r11 gs     ; Get the size of gs, and store in r11 
-    call println
+    size r11 gs     ; Get the size of gs, and store in r11 (should be 5)
+    size r11 ls     ; Should be 0 
+
+    push ls r0
+    push ls r0
+
+    size r11 ls     ; Should be 2
+
+    pop r0 ls 
+    
+    size r11 ls     ; Should be 1
 >
 
 <testregrefgs:

--- a/src/apps/solace/solace_code/new_ins.asm
+++ b/src/apps/solace/solace_code/new_ins.asm
@@ -60,13 +60,14 @@
 
     stb r4(gs) r5  ; Store 33 into gs at index 4
 
-    ldb r11 $4(gs)
+    ldb r11 $4(gs) ; Should get 33 from gs
 >
 
 <testregrefls:
 
     mov r0 $99
 
+    ; Put a few 99s in the stack so we have something to work with
     push ls r0
     push ls r0
     push ls r0
@@ -76,6 +77,10 @@
     mov r7 $45
 
     stb r0(ls) r7  ; Store 45 into index 2 (spot 3) of ls
-    ldb r11 r0(ls) ; Load index 2 (spot 3) into rll
+    ldb r11 r0(ls) ; Load index 2 (spot 3) into rll -> Should be 45
+    ldb r11 $2(ls) ; Load index 2 (spot 3) into rll -> Should be 45
 
+    mov r0 $3
+    ldb r11 r0(ls) ; Load index 2 (spot 3) into rll -> Should be 99
+    ldb r11 $3(ls) ; Should be 99
 >

--- a/src/apps/solace/solace_code/new_ins.asm
+++ b/src/apps/solace/solace_code/new_ins.asm
@@ -1,42 +1,70 @@
-.file "newasm"
+.file "extend_load_store"
+
+.int64 test  8675309
+.int64 nl    720575940379279360     ; Encoded new line char
+
 .init main
+
+; Calls print on whatever is currently ready to rock
+; Then prints the endline char
+<println:
+    mov r10 $2
+    ldb r11 $1(gs)
+    mov r10 $2
+>
 
 <main:
 
-    mov r9  $8
-    mov r10 $4
-    mov r11 $1
+    ; Stack starts as size 2
+    ldb r0 $0(gs)
 
-    lsh r0 r9 $4    ; 128
-    lsh r0 r9 r10   ; 128
-    lsh r0 $4 r9    ; 1024
-    lsh r0 $4 $8    ; 1024
+    ; Push to make stack size 5 (0 -> 4)
+    push gs r0
+    push gs r0
+    push gs r0
 
-    rsh r0 r9 $4       ; 0
-    rsh r0 r9 r10      ; 0
-    rsh r0 $1024 r9    ; 4 
-    rsh r0 $1024 $8    ; 4 
+    ; Print '*'
+    mov r11 $42 
+    call println
 
-    and r0 r10 $4    ; 4
-    and r0 r9 r10    ; 0
-    and r0 $4 r9     ; 0
-    and r0 $4 $4     ; 4
+    ; New Instructions
+    call testsize       ; Test size
+    call testregrefgs   ; Test register reference on global stack
+    call testregrefls   ; Test register reference on local stack
+>
 
-    or r0 r9 $4     ; 12
-    or r0 r9 r10    ; 12
-    or r0 $4 r9     ; 12
-    or r0 $4 $8     ; 12
 
-    xor r0 r9 $4    ; 12
-    xor r0 r9 r10   ; 12
-    xor r0 $4 r9    ; 12
-    xor r0 $4 $8    ; 12
+<testsize:
 
-    not r0 $1       ; -2
-    not r0 r11      ; -2
+    ;size r11 gs     ; Get the size of gs, and store in r11 
+    call println
+>
 
-    nop
-    nop
+<testregrefgs:
 
-    ret
+    mov r4 $0
+
+    ;ldb r11 r4(gs) ; Load the 0th item from global stack (should be constant 'test')
+
+    mov r4 $4
+    mov r5 $33
+
+    ;stb r4(gs) r5  ; Store 33 into gs at index 4
+>
+
+<testregrefls:
+
+    mov r0 $99
+
+    push ls r0
+    push ls r0
+    push ls r0
+    push ls r0
+
+    mov r0 $2
+    mov r7 $45
+
+    ;stb r0(ls) r7  ; Store 45 into index 2 (spot 3) of ls
+    ;ldb r11 r0(ls) ; Load index 2 (spot 3) into rll
+
 >

--- a/src/apps/solace/tests/CMakeLists.txt
+++ b/src/apps/solace/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(nablaInsTest
         nopTests.cpp
         pushpopTests.cpp
         returnTests.cpp
+        sizeTests.cpp
         stbldbTests.cpp
         main.cpp
 )

--- a/src/apps/solace/tests/sizeTests.cpp
+++ b/src/apps/solace/tests/sizeTests.cpp
@@ -1,0 +1,86 @@
+#include <iostream>
+#include "bytegen.hpp"
+#include "VmInstructions.h"
+#include <random>
+#include "CppUTest/TestHarness.h"
+
+namespace
+{
+    uint8_t getRandom8(uint8_t low, uint8_t high)
+    {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(low, high);
+        return dis(gen);
+    }
+    
+    // Just in case the register addresses need to change, we don't want to have to change
+    // the tests to accomodate
+    uint8_t integerToRegister(int16_t reg)
+    {
+        switch(reg)
+        {
+            case 0 : return REGISTER_0 ;
+            case 1 : return REGISTER_1 ;
+            case 2 : return REGISTER_2 ;
+            case 3 : return REGISTER_3 ;
+            case 4 : return REGISTER_4 ;
+            case 5 : return REGISTER_5 ;
+            case 6 : return REGISTER_6 ;
+            case 7 : return REGISTER_7 ;
+            case 8 : return REGISTER_8 ;
+            case 9 : return REGISTER_9 ;
+            case 10: return REGISTER_10;
+            case 11: return REGISTER_11;
+            case 12: return REGISTER_12;
+            case 13: return REGISTER_13;
+            case 14: return REGISTER_14;
+            case 15: return REGISTER_15;
+            default: 
+                std::cerr << "Someone tried something silly with : " << reg  << ". IN THE BRANCH TEST!" << std::endl;
+                exit(EXIT_FAILURE); 
+                break;
+        }
+    }
+}
+
+TEST_GROUP(SizeTests)
+{   
+    NABLA::Bytegen byteGen;
+    
+};
+
+// ---------------------------------------------------------------
+// 
+// ---------------------------------------------------------------
+
+TEST(SizeTests, AllSizeTests)
+{
+    for(int16_t j = 0; j < 100; j++)
+    {
+        NABLA::Bytegen::Instruction expectedIns;
+
+        NABLA::Bytegen::Stacks stack = (j % 2 == 0) ? NABLA::Bytegen::Stacks::GLOBAL : NABLA::Bytegen::Stacks::LOCAL;
+
+        expectedIns.bytes[0] = INS_SIZE;
+        expectedIns.bytes[1] = integerToRegister(getRandom8(0, 9));
+        expectedIns.bytes[2] = (stack == NABLA::Bytegen::Stacks::GLOBAL) ? GLOBAL_STACK : LOCAL_STACK;
+        expectedIns.bytes[3] = 0xFF;
+        expectedIns.bytes[4] = 0xFF;
+        expectedIns.bytes[5] = 0xFF;
+        expectedIns.bytes[6] = 0xFF;
+        expectedIns.bytes[7] = 0xFF;
+
+        NABLA::Bytegen::Instruction ins = byteGen.createSizeInstruction(expectedIns.bytes[1], stack);
+
+        // Build expected ins
+        CHECK_EQUAL_TEXT(ins.bytes[0], expectedIns.bytes[0], "Opcode fail");
+        CHECK_EQUAL_TEXT(ins.bytes[1], expectedIns.bytes[1], "Byte 1 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[2], expectedIns.bytes[2], "Byte 2 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[3], expectedIns.bytes[3], "Byte 3 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[4], expectedIns.bytes[4], "Byte 4 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[5], expectedIns.bytes[5], "Byte 5 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[6], expectedIns.bytes[6], "Byte 6 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[7], expectedIns.bytes[7], "Byte 7 fail");
+    }
+}

--- a/src/apps/solace/tests/stbldbTests.cpp
+++ b/src/apps/solace/tests/stbldbTests.cpp
@@ -80,7 +80,7 @@ TEST_GROUP(StbLdbTests)
 // 
 // ---------------------------------------------------------------
 
-TEST(StbLdbTests, Stb)
+TEST(StbLdbTests, StbNumberBased)
 {
     for(int16_t j = 0; j < 50; j++)
     {
@@ -101,6 +101,7 @@ TEST(StbLdbTests, Stb)
         
         NABLA::Bytegen::Instruction ins = byteGen.createStbInstruction(
             stackType,
+            NABLA::Bytegen::LoadStoreSetup::NUMBER_BASED,
             location,
             expectedIns.bytes[6]
         );
@@ -123,7 +124,47 @@ TEST(StbLdbTests, Stb)
 // 
 // ---------------------------------------------------------------
 
-TEST(StbLdbTests, Ldb)
+TEST(StbLdbTests, StbRegisterBased)
+{
+    for(int16_t j = 0; j < 50; j++)
+    {
+        NABLA::Bytegen::Instruction expectedIns;
+
+        NABLA::Bytegen::Stacks stackType = (j % 2 == 0) ? NABLA::Bytegen::Stacks::GLOBAL : NABLA::Bytegen::Stacks::LOCAL;
+
+        expectedIns.bytes[0] = (INS_STB | 0x01);
+        expectedIns.bytes[1] = getStackAddress(stackType);
+        expectedIns.bytes[2] = integerToRegister(getRandom8(0, 9));
+        expectedIns.bytes[3] = integerToRegister(getRandom8(0, 9));
+        expectedIns.bytes[4] = 0xFF;
+        expectedIns.bytes[5] = 0xFF;
+        expectedIns.bytes[6] = 0xFF;
+        expectedIns.bytes[7] = 0xFF;
+        
+        NABLA::Bytegen::Instruction ins = byteGen.createStbInstruction(
+            stackType,
+            NABLA::Bytegen::LoadStoreSetup::REGISTER_BASED,
+            expectedIns.bytes[2],
+            expectedIns.bytes[3]
+        );
+
+        // Build expected ins
+        CHECK_EQUAL_TEXT(ins.bytes[0], expectedIns.bytes[0], "Opcode fail");
+        CHECK_EQUAL_TEXT(ins.bytes[1], expectedIns.bytes[1], "Incorrect Stack");
+        CHECK_EQUAL_TEXT(ins.bytes[2], expectedIns.bytes[2], "Byte 1 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[3], expectedIns.bytes[3], "Byte 3 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[4], expectedIns.bytes[4], "Byte 4 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[5], expectedIns.bytes[5], "Byte 5 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[6], expectedIns.bytes[6], "Byte 6 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[7], expectedIns.bytes[7], "Byte 7 fail");
+    }   
+}
+
+// ---------------------------------------------------------------
+// 
+// ---------------------------------------------------------------
+
+TEST(StbLdbTests, LdbNumberBased)
 {
     for(int16_t j = 0; j < 50; j++)
     {
@@ -144,6 +185,7 @@ TEST(StbLdbTests, Ldb)
         
         NABLA::Bytegen::Instruction ins = byteGen.createLdbInstruction(
             stackType,
+            NABLA::Bytegen::LoadStoreSetup::NUMBER_BASED,
             location,
             expectedIns.bytes[1]
         );
@@ -158,6 +200,44 @@ TEST(StbLdbTests, Ldb)
         CHECK_EQUAL_TEXT(ins.bytes[6], expectedIns.bytes[6], "Byte 6 fail");
         CHECK_EQUAL_TEXT(ins.bytes[7], expectedIns.bytes[7], "Byte 7 fail");
     }
+}
 
-    
+// ---------------------------------------------------------------
+// 
+// ---------------------------------------------------------------
+
+TEST(StbLdbTests, LdbRegisterBased)
+{
+    for(int16_t j = 0; j < 50; j++)
+    {
+        NABLA::Bytegen::Instruction expectedIns;
+
+        NABLA::Bytegen::Stacks stackType = (j % 2 == 0) ? NABLA::Bytegen::Stacks::GLOBAL : NABLA::Bytegen::Stacks::LOCAL;
+        
+        expectedIns.bytes[0] = (INS_LDB | 0x01);
+        expectedIns.bytes[1] = integerToRegister(getRandom8(0, 9));
+        expectedIns.bytes[2] = getStackAddress(stackType);
+        expectedIns.bytes[3] = integerToRegister(getRandom8(0, 9));
+        expectedIns.bytes[4] = 0xFF;
+        expectedIns.bytes[5] = 0xFF;
+        expectedIns.bytes[6] = 0xFF;
+        expectedIns.bytes[7] = 0xFF;
+        
+        NABLA::Bytegen::Instruction ins = byteGen.createLdbInstruction(
+            stackType,
+            NABLA::Bytegen::LoadStoreSetup::REGISTER_BASED,
+            expectedIns.bytes[3],
+            expectedIns.bytes[1]
+        );
+
+        // Build expected ins
+        CHECK_EQUAL_TEXT(ins.bytes[0], expectedIns.bytes[0], "Opcode fail");
+        CHECK_EQUAL_TEXT(ins.bytes[1], expectedIns.bytes[1], "Incorrect Register");
+        CHECK_EQUAL_TEXT(ins.bytes[2], expectedIns.bytes[2], "Incorrect stack");
+        CHECK_EQUAL_TEXT(ins.bytes[3], expectedIns.bytes[3], "Byte 3 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[4], expectedIns.bytes[4], "Byte 4 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[5], expectedIns.bytes[5], "Byte 5 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[6], expectedIns.bytes[6], "Byte 6 fail");
+        CHECK_EQUAL_TEXT(ins.bytes[7], expectedIns.bytes[7], "Byte 7 fail");
+    }
 }

--- a/src/libc/vm/VmInstructions.h
+++ b/src/libc/vm/VmInstructions.h
@@ -1,6 +1,7 @@
 #ifndef VM_INSTRUCTIONS_H
 #define VM_INSTRUCTIONS_H
     #define INS_NOP             0x00
+    #define INS_SIZE            0x04
     #define INS_LSH             0x44
     #define INS_RSH             0x48
     #define INS_AND             0x4c

--- a/src/libc/vm/vm.c
+++ b/src/libc/vm/vm.c
@@ -660,6 +660,30 @@ int vm_cycle(struct VM* vm, uint64_t n)
                 assert(okay == STACK_OKAY);
                 break;
             }          
+            case INS_SIZE :
+            {
+                uint8_t destReg         = util_extract_byte(ins, 6);
+                uint8_t stackInQuestion = util_extract_byte(ins, 5);
+
+                if(stackInQuestion == GLOBAL_STACK)
+                {
+                    vm->registers[destReg] = stack_get_size(vm->globalStack);
+                }
+                else if (stackInQuestion == LOCAL_STACK )
+                {
+                    vm->registers[destReg] = stack_get_size(vm->functions[vm->fp].localStack);
+                }
+                else
+                {
+                    printf("Invalid 'size' instruction!\n");
+                    return VM_RUN_ERROR_UNKNOWN_INSTRUCTION;
+                }
+                
+#ifdef NABLA_VIRTUAL_MACHINE_DEBUG_OUTPUT
+                printf("Size Result : %lu\n", vm->registers[destReg]);
+#endif
+                break;
+            }
             case INS_JUMP :
             {
                 uint64_t destAddress = (uint64_t)util_extract_two_bytes(ins, 6) << 16| 

--- a/src/libc/vm/vm.c
+++ b/src/libc/vm/vm.c
@@ -582,44 +582,102 @@ int vm_cycle(struct VM* vm, uint64_t n)
             case INS_LDB  :
             {
                 uint8_t dest =  util_extract_byte(ins, 6);
-
-                uint8_t stackSouce = util_extract_byte(ins, 5);
-
-                uint64_t sourceAddress = (uint64_t)util_extract_two_bytes(ins, 4) << 16| 
-                                         (uint64_t)util_extract_two_bytes(ins, 2);
-
-                int okay = -255;
-                if(stackSouce == GLOBAL_STACK)
+                if(id == 0)
                 {
-                    vm->registers[dest] = stack_value_at(sourceAddress, vm->globalStack, &okay);
+                    uint8_t stackSouce = util_extract_byte(ins, 5);
+
+                    uint64_t sourceAddress = (uint64_t)util_extract_two_bytes(ins, 4) << 16| 
+                                            (uint64_t)util_extract_two_bytes(ins, 2);
+
+                    int okay = -255;
+                    if(stackSouce == GLOBAL_STACK)
+                    {
+                        vm->registers[dest] = stack_value_at(sourceAddress, vm->globalStack, &okay);
+                    }
+                    else if ( stackSouce == LOCAL_STACK )
+                    {
+                        vm->registers[dest] = stack_value_at(sourceAddress, vm->functions[vm->fp].localStack, &okay);
+                    }
+                    assert(okay == STACK_OKAY);
                 }
-                else if ( stackSouce == LOCAL_STACK )
+                else if (id == 1)
                 {
-                    vm->registers[dest] = stack_value_at(sourceAddress, vm->functions[vm->fp].localStack, &okay);
+
+                    uint8_t stackSouce = util_extract_byte(ins, 5);
+
+                    uint8_t sourceReg  = util_extract_byte(ins, 4);
+
+                    uint64_t sourceAddress = vm->registers[sourceReg];
+
+                    int okay = -255;
+                    if(stackSouce == GLOBAL_STACK)
+                    {
+                        vm->registers[dest] = stack_value_at(sourceAddress, vm->globalStack, &okay);
+                    }
+                    else if ( stackSouce == LOCAL_STACK )
+                    {
+                        vm->registers[dest] = stack_value_at(sourceAddress, vm->functions[vm->fp].localStack, &okay);
+                    }
+                    assert(okay == STACK_OKAY);
                 }
-                assert(okay == STACK_OKAY);
+                else
+                {
+                    printf("Invalid 'ldb' instruction id : ID= %u\n", id);
+                    return VM_RUN_ERROR_UNKNOWN_INSTRUCTION;
+                }
+#ifdef NABLA_VIRTUAL_MACHINE_DEBUG_OUTPUT
+                    printf("Ldb Result: %lu\n", vm->registers[dest]);
+#endif
                 break;
             }          
             case INS_STB  :
             {
-                uint8_t sourceReg =  util_extract_byte(ins, 1);
-
-                uint8_t stackDest = util_extract_byte(ins, 6);
-
-                uint64_t desAddress = (uint64_t)util_extract_two_bytes(ins, 5) << 16| 
-                                      (uint64_t)util_extract_two_bytes(ins, 3);
-
-                int okay = -255;
-                if(stackDest == GLOBAL_STACK)
+                if(id == 0)
                 {
-                    stack_set_value_at(desAddress, vm->registers[sourceReg], vm->globalStack, &okay);
+                    uint8_t sourceReg =  util_extract_byte(ins, 1);
+
+                    uint8_t stackDest = util_extract_byte(ins, 6);
+
+                    uint64_t desAddress = (uint64_t)util_extract_two_bytes(ins, 5) << 16| 
+                                        (uint64_t)util_extract_two_bytes(ins, 3);
+
+                    int okay = -255;
+                    if(stackDest == GLOBAL_STACK)
+                    {
+                        stack_set_value_at(desAddress, vm->registers[sourceReg], vm->globalStack, &okay);
+                    }
+                    else if ( stackDest == LOCAL_STACK )
+                    {
+                        // If they haven't made the local stack big enough this could fail. Hope they know what they're doing
+                        stack_set_value_at(desAddress, vm->registers[sourceReg], vm->functions[vm->fp].localStack, &okay);
+                    }
+                    assert(okay == STACK_OKAY);
                 }
-                else if ( stackDest == LOCAL_STACK )
+                else if (id == 1)
                 {
-                    // If they haven't made the local stack big enough this could fail. Hope they know what they're doing
-                    stack_set_value_at(desAddress, vm->registers[sourceReg], vm->functions[vm->fp].localStack, &okay);
+                    uint8_t sourceReg = util_extract_byte(ins, 4);
+                    uint8_t stackDest = util_extract_byte(ins, 6);
+                    uint8_t destReg   = util_extract_byte(ins, 5);
+
+                    uint64_t desAddress = vm->registers[destReg];
+
+                    int okay = -255;
+                    if(stackDest == GLOBAL_STACK)
+                    {
+                        stack_set_value_at(desAddress, vm->registers[sourceReg], vm->globalStack, &okay);
+                    }
+                    else if ( stackDest == LOCAL_STACK )
+                    {
+                        // If they haven't made the local stack big enough this could fail. Hope they know what they're doing
+                        stack_set_value_at(desAddress, vm->registers[sourceReg], vm->functions[vm->fp].localStack, &okay);
+                    }
+                    assert(okay == STACK_OKAY);
                 }
-                assert(okay == STACK_OKAY);
+                else
+                {
+                    printf("Invalid 'stb' instruction id : ID= %u\n", id);
+                    return VM_RUN_ERROR_UNKNOWN_INSTRUCTION;
+                }
                 break;
             }          
             case INS_PUSH :

--- a/src/libcpp/bytegen/bytegen.cpp
+++ b/src/libcpp/bytegen/bytegen.cpp
@@ -493,18 +493,43 @@ namespace NABLA
     // createStbInstruction
     // ------------------------------------------------------------------------
     
-    Bytegen::Instruction Bytegen::createStbInstruction(Stacks stack, uint32_t location, uint8_t reg)
+    Bytegen::Instruction Bytegen::createStbInstruction(Stacks stack, LoadStoreSetup setup, uint32_t location, uint8_t reg)
     {
         Instruction ins;
 
-        ins.bytes[0] = INS_STB;
-        ins.bytes[1] = getStackAddress(stack);
-        ins.bytes[2] = (location & 0xFF000000) >> 24 ;
-        ins.bytes[3] = (location & 0x00FF0000) >> 16 ;
-        ins.bytes[4] = (location & 0x0000FF00) >> 8  ;
-        ins.bytes[5] = (location & 0x000000FF) >> 0  ;
-        ins.bytes[6] = integerToRegister(reg);
-        ins.bytes[7] = 0xFF;
+        switch(setup)
+        {
+            case Bytegen::LoadStoreSetup::NUMBER_BASED:
+            {
+                ins.bytes[0] = INS_STB;
+                ins.bytes[1] = getStackAddress(stack);
+                ins.bytes[2] = (location & 0xFF000000) >> 24 ;
+                ins.bytes[3] = (location & 0x00FF0000) >> 16 ;
+                ins.bytes[4] = (location & 0x0000FF00) >> 8  ;
+                ins.bytes[5] = (location & 0x000000FF) >> 0  ;
+                ins.bytes[6] = integerToRegister(reg);
+                ins.bytes[7] = 0xFF;
+                break;
+            }
+
+            case Bytegen::LoadStoreSetup::REGISTER_BASED:
+            {
+                ins.bytes[0] = (INS_STB | 0x01);
+                ins.bytes[1] = getStackAddress(stack);
+                ins.bytes[2] = integerToRegister(location);
+                ins.bytes[3] = integerToRegister(reg);
+                ins.bytes[4] = 0xFF;
+                ins.bytes[5] = 0xFF;
+                ins.bytes[6] = 0xFF;
+                ins.bytes[7] = 0xFF;
+                break;
+            }
+            default:
+                std::cerr << "Someone is doing something wrong with bytegen createStbInstruction!" << std::endl;
+                exit(EXIT_FAILURE); 
+                break;
+        }
+
 
         //dumpInstruction(ins);
 
@@ -515,18 +540,43 @@ namespace NABLA
     // createLdbInstruction
     // ------------------------------------------------------------------------
     
-    Bytegen::Instruction Bytegen::createLdbInstruction(Stacks stack, uint32_t location, uint8_t reg)
+    Bytegen::Instruction Bytegen::createLdbInstruction(Stacks stack, LoadStoreSetup setup, uint32_t location, uint8_t reg)
     {
         Instruction ins;
 
-        ins.bytes[0] = INS_LDB;
-        ins.bytes[1] = integerToRegister(reg);
-        ins.bytes[2] = getStackAddress(stack);
-        ins.bytes[3] = (location & 0xFF000000) >> 24 ;
-        ins.bytes[4] = (location & 0x00FF0000) >> 16 ;
-        ins.bytes[5] = (location & 0x0000FF00) >> 8  ;
-        ins.bytes[6] = (location & 0x000000FF) >> 0  ;
-        ins.bytes[7] = 0xFF;
+        switch(setup)
+        {
+            case Bytegen::LoadStoreSetup::NUMBER_BASED:
+            {
+                ins.bytes[0] = INS_LDB;
+                ins.bytes[1] = integerToRegister(reg);
+                ins.bytes[2] = getStackAddress(stack);
+                ins.bytes[3] = (location & 0xFF000000) >> 24 ;
+                ins.bytes[4] = (location & 0x00FF0000) >> 16 ;
+                ins.bytes[5] = (location & 0x0000FF00) >> 8  ;
+                ins.bytes[6] = (location & 0x000000FF) >> 0  ;
+                ins.bytes[7] = 0xFF;
+                break;
+            }
+
+            case Bytegen::LoadStoreSetup::REGISTER_BASED:
+            {
+                ins.bytes[0] = (INS_LDB | 0x01);
+                ins.bytes[1] = integerToRegister(reg);
+                ins.bytes[2] = getStackAddress(stack);
+                ins.bytes[3] = integerToRegister(location);
+                ins.bytes[4] = 0xFF;
+                ins.bytes[5] = 0xFF;
+                ins.bytes[6] = 0xFF;
+                ins.bytes[7] = 0xFF;
+                break;
+            }
+
+            default:
+                std::cerr << "Someone is doing something wrong with bytegen createLdbInstruction!" << std::endl;
+                exit(EXIT_FAILURE); 
+                break;
+        }
 
         //dumpInstruction(ins);
 

--- a/src/libcpp/bytegen/bytegen.cpp
+++ b/src/libcpp/bytegen/bytegen.cpp
@@ -836,4 +836,24 @@ namespace NABLA
         return ins;
     }
 
+    // ------------------------------------------------------------------------
+    // 
+    // ------------------------------------------------------------------------
+
+    Bytegen::Instruction Bytegen::createSizeInstruction(uint8_t reg, Stacks stack)
+    {
+        Instruction ins;
+
+        ins.bytes[0] = INS_SIZE;
+        ins.bytes[1] = integerToRegister(reg);
+        ins.bytes[2] = getStackAddress(stack);
+        ins.bytes[3] = 0xFF;
+        ins.bytes[4] = 0xFF;
+        ins.bytes[5] = 0xFF;
+        ins.bytes[6] = 0xFF;
+        ins.bytes[7] = 0xFF;
+
+        return ins;
+    }
+
 } // End of namespace

--- a/src/libcpp/bytegen/bytegen.hpp
+++ b/src/libcpp/bytegen/bytegen.hpp
@@ -238,6 +238,11 @@ namespace NABLA
         //! \brief Create a no-op instruction
         Instruction createNopInstruction();
 
+        //! \brief Create a 'size' instruction
+        //! \param reg The destination register
+        //! \param stack The stack to get the size of
+        Instruction createSizeInstruction(uint8_t reg, Stacks stack);
+
     private:
 
         uint32_t functionCounter;

--- a/src/libcpp/bytegen/bytegen.hpp
+++ b/src/libcpp/bytegen/bytegen.hpp
@@ -121,6 +121,15 @@ namespace NABLA
         };
 
         //!
+        //! \brief Setup configuration for load store commands
+        //!
+        enum class LoadStoreSetup
+        {
+            NUMBER_BASED    = 0x00,
+            REGISTER_BASED  = 0x01
+        };
+
+        //!
         //! \brief Create a bytegen
         //!
         Bytegen();
@@ -195,15 +204,17 @@ namespace NABLA
 
         //! \brief Create a pop instruction
         //! \param stack The stack to put data in
+        //! \param setup Indicate what location is to be encoded as (number or register)
         //! \param location The location in the stack to put the data
         //! \param reg   The register to get the data
-        Instruction createStbInstruction(Stacks stack, uint32_t location, uint8_t reg);
+        Instruction createStbInstruction(Stacks stack, LoadStoreSetup setup, uint32_t location, uint8_t reg);
 
         //! \brief Create a pop instruction
         //! \param stack The stack to get data from
+        //! \param setup Indicate what location is to be encoded as (number or register)
         //! \param location The location in the stack to get the data
         //! \param reg   The register to put the data
-        Instruction createLdbInstruction(Stacks stack, uint32_t location, uint8_t reg);
+        Instruction createLdbInstruction(Stacks stack, LoadStoreSetup setup, uint32_t location, uint8_t reg);
 
         //! \brief Create return instruction
         Instruction createReturnInstruction();


### PR DESCRIPTION
ldb and stb can now be used with registers to key their stack index. 

**ldb r0 $0(gs)**  was the only previous way to ldb.  Now, in addition to that : 

**ldb r0 r9(gs)**   can be used. Value stored in r9 (or whatever register) will now be used to index the global (gs) or local (ls) stack.

Same thing goes for stb. Check out asm_instructions.md!